### PR TITLE
Improved Readme markdown

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 uporersith
+Copyright (c) 2023 uporersith
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -27,19 +27,14 @@ Script requires grep to be installed.
 
 outputs **fds.vim**
 
-Place the fds.vim file in the vim syntax folder[^1] and add the line:
+---
+
+Place the generated **fds.vim** file in the vim syntax folder[^1] and add the line:
 ```sh
 au BufNewFile,BufRead *.fds	setf fds
 ```
 To the filetype.vim file[^2]
 
----
-
-[^1]: Common install locations
-- $HOME/.vim/syntax (unix-based)
-- $/HOME/vimfiles/syntax (unix-based)
-- \<Program files\>\Vim\vim\<version\>\syntax (windows)
-[^2]: Typically located in 
-- /usr/share/vim/vim\<version\>/filetype.vim (unix-based)
-- \<Program Files\>\Vim\vim\<version\>\filetype.vim (windows)
+[^1]: Common install locations $HOME/.vim/syntax (unix-based), $/HOME/vimfiles/syntax (unix-based) and \<Program files\>\Vim\vim\<version\>\syntax (windows)
+[^2]: Typically located in /usr/share/vim/vim\<version\>/filetype.vim (unix-based) and \<Program Files\>\Vim\vim\<version\>\filetype.vim (windows)
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@ Syntax file for the VIM text Editor for Fire Dynamics Simulator Input files.
 
 Script requires grep to be installed.
 
-usage:
+## Usage
  1) clone a copy of the Git Repository:
-$git clone https://github.com/firemodels/fds.git
+ ```sh
+ $git clone https://github.com/firemodels/fds.git
+ ```
  2) show the list of tags to get the latest stable release:
  	$cd fds
  	$git tag
@@ -17,12 +19,27 @@ $git clone https://github.com/firemodels/fds.git
  3) checkout the latest stable release
  	$git checkout 'FDS6.7.0'
  4) switch to the Source dir, then run the script:
- fds_make_syn.pl 
+ ```sh
+ fds_make_syn.pl
+ ```
  The script will find all files with the NAMELIST keyword and and parses all the lines: NAMELIST ....
  to get all the syntax keywords
 
-outputs fds.vim
-Place the fds.vim file in the $HOME/vimfiles/syntax folder
-add the line:
-	au BufNewFile,BufRead *.fds	setf fds
-To the filetype.vim file
+outputs **fds.vim**
+
+Place the fds.vim file in the vim syntax folder[^1] and add the line:
+```sh
+au BufNewFile,BufRead *.fds	setf fds
+```
+To the filetype.vim file[^2]
+
+---
+
+[^1]: Common install locations
+- $HOME/.vim/syntax (unix-based)
+- $/HOME/vimfiles/syntax (unix-based)
+- \<Program files\>\Vim\vim\<version\>\syntax (windows)
+[^2]: Typically located in 
+- /usr/share/vim/vim\<version\>/filetype.vim (unix-based)
+- \<Program Files\>\Vim\vim\<version\>\filetype.vim (windows)
+

--- a/fds.vim
+++ b/fds.vim
@@ -303,7 +303,7 @@ syn match hBool /\(\.TRUE\.\)\|\(\.FALSE\.\)/ contained
 "Numbers of various sorts, Copied the Fortran syntax file
 
 " Integers
-syn match FDSInterger	display "\<\d\+\(_\a\w*\)\=\>"
+syn match FDSInteger	display "\<\d\+\(_\a\w*\)\=\>"
 " floating point number, without a decimal point
 syn match FDSFloat	display	"\<\d\+[deEq][-+]\=\d\+\(_\a\w*\)\=\>"
 " floating point number, starting with a decimal point
@@ -321,7 +321,7 @@ syn match FDSOperator	"\(\(>\|<\)=\=\|==\|/=\|=\)"
 syntax region hString start=/"\|'/ end=/"\|'/ contained
 
 " instructions - Anything that begins with & and end with /
-syn region instructions start=/^\s*&/ end=/[/]/ contains=FDS4OBS,hstring,FDS5PA,NAMELIST,FDSNumber,FDSFloat,FDSInterger,FDSOperator,hBool contained
+syn region instructions start=/^\s*&/ end=/[/]/ contains=FDS4OBS,hstring,FDS5PA,NAMELIST,FDSNumber,FDSFloat,FDSInteger,FDSOperator,hBool contained
 
 " comments: everything is a comment, unless it is an instruction, see above
 syn match  comment /.*/ contains=instructions
@@ -344,7 +344,7 @@ if version >= 508 || !exists("did_blank_syntax_inits")
   HiLink FDS4OBS		Error
   HiLink instructions		Statement
   HiLink FDSNumber 		Number
-  HiLink FDSInterger		Number
+  HiLink FDSInteger		Number
   HiLink FDSFloat		Number
   HiLink hBool			Boolean
   HiLink comment		Comment

--- a/fds_make_syn.pl
+++ b/fds_make_syn.pl
@@ -197,7 +197,7 @@ sub print_footer{
 	print SYNOUT "\"Numbers of various sorts, Copied the Fortran syntax file\n";
 	print SYNOUT "\n";
 	print SYNOUT "\" Integers\n";
-	print SYNOUT "syn match FDSInterger	display \"\\<\\d\\+\\(_\\a\\w*\\)\\=\\>\"\n";
+	print SYNOUT "syn match FDSInteger	display \"\\<\\d\\+\\(_\\a\\w*\\)\\=\\>\"\n";
 	print SYNOUT "\" floating point number, without a decimal point\n";
 	print SYNOUT "syn match FDSFloat	display	\"\\<\\d\\+[deq][-+]\\=\\d\\+\\(_\\a\\w*\\)\\=\\>\"\n";
 	print SYNOUT "\" floating point number, starting with a decimal point\n";
@@ -215,7 +215,7 @@ sub print_footer{
 	print SYNOUT "syntax region hString start=/\"\\|\'/ end=/\"\\|\'/ contained\n";
 	print SYNOUT "\n";
 	print SYNOUT "\" instructions - Anything that begins with & and end with /\n";
-	print SYNOUT "syn region instructions start=/^\\s*&/ end=/[/]/ contains=FDS4OBS,hstring,FDS5PA,NAMELIST,FDSNumber,FDSFloat,FDSInterger,FDSOperator,hBool contained\n";
+	print SYNOUT "syn region instructions start=/^\\s*&/ end=/[/]/ contains=FDS4OBS,hstring,FDS5PA,NAMELIST,FDSNumber,FDSFloat,FDSInteger,FDSOperator,hBool contained\n";
 	print SYNOUT "\n";
 	print SYNOUT "\" comments: everything is a comment, unless it is an instruction, see above\n";
 	print SYNOUT "syn match  comment /.*/ contains=instructions\n";
@@ -238,7 +238,7 @@ sub print_footer{
 	print SYNOUT "  HiLink FDS4OBS		Error\n";
 	print SYNOUT "  HiLink instructions		Statement\n";
 	print SYNOUT "  HiLink FDSNumber 		Number\n";
-	print SYNOUT "  HiLink FDSInterger		Number\n";
+	print SYNOUT "  HiLink FDSInteger		Number\n";
 	print SYNOUT "  HiLink FDSFloat		Number\n";
 	print SYNOUT "  HiLink hBool			Boolean\n";
 	print SYNOUT "  HiLink comment		Comment\n";


### PR DESCRIPTION
Hi Andrew,

Just wanted to show my appreciation for this with an update to the markdown for those using windows and unix copies of vim. I also did a small bit of variable rewording (Interger => Integer).

I should also mention - OpenFOAM file syntax is now being recognised automatically in VIM (There's a line for it present in the VIM9.0 filetype.vim file), it might be worth a discussion with them about getting your syntax highlighting into vim now that FDS is quite mature in its keywords?

Thanks,

Sam.